### PR TITLE
fix(ci): repair Sonar pipelines and standardize lib/app builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Normalize line endings to LF on commit so Prettier's eol:lf check
+# passes identically on Windows, macOS, and Linux / CI.
+* text=auto eol=lf
+
+# Binary assets — never normalize.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary

--- a/.github/workflows/nebula-chat-client.yml
+++ b/.github/workflows/nebula-chat-client.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Build
         run: pnpm turbo run build --filter=nebula-chat-client
       - name: SonarQube scan
+        if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         with:
           projectBaseDir: apps/nebula-chat-client
@@ -74,12 +75,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Evaluate quality gate
         id: quality_gate
+        if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-quality-gate-action@v1.2.0
         with:
           scanMetadataReportFile: apps/nebula-chat-client/.scannerwork/report-task.txt
           pollingTimeoutSec: 300
       - name: Publish Sonar summary
-        if: always()
+        if: ${{ always() && env.SONAR_TOKEN != '' }}
         run: |
           report_file='apps/nebula-chat-client/.scannerwork/report-task.txt'
           dashboard_url=''
@@ -98,7 +100,7 @@ jobs:
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
       - name: Comment quality gate in PR
-        if: github.event_name == 'pull_request' && always()
+        if: ${{ always() && github.event_name == 'pull_request' && env.SONAR_TOKEN != '' }}
         run: pnpm exec tsx scripts/post-sonar-quality-comment.ts
         env:
           APP_NAME: nebula-chat-client

--- a/.github/workflows/nebula-chat-db.yml
+++ b/.github/workflows/nebula-chat-db.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'libs/db/**'
+      - 'scripts/post-sonar-quality-comment.ts'
       - '.github/workflows/nebula-chat-db.yml'
   pull_request:
     branches: [main]
     paths:
       - 'libs/db/**'
+      - 'scripts/post-sonar-quality-comment.ts'
       - '.github/workflows/nebula-chat-db.yml'
   workflow_dispatch:
 
@@ -48,11 +50,16 @@ jobs:
             turbo-db-
       - name: Install dependencies
         run: pnpm install --ignore-scripts
-      - name: Build
-        run: pnpm turbo run build --filter=@nebula-chat/db
+      - name: Lint
+        run: pnpm exec eslint --report-unused-disable-directives --max-warnings=0 libs/db/
+      - name: Format check
+        run: pnpm exec prettier --check libs/db/
       - name: TypeScript check
         run: pnpm turbo run typecheck --filter=@nebula-chat/db
+      - name: Build
+        run: pnpm turbo run build --filter=@nebula-chat/db
       - name: SonarQube scan
+        if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         with:
           projectBaseDir: libs/db
@@ -68,12 +75,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Evaluate quality gate
         id: quality_gate
+        if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-quality-gate-action@v1.2.0
         with:
           scanMetadataReportFile: libs/db/.scannerwork/report-task.txt
           pollingTimeoutSec: 300
       - name: Publish Sonar summary
-        if: always()
+        if: ${{ always() && env.SONAR_TOKEN != '' }}
         run: |
           report_file='libs/db/.scannerwork/report-task.txt'
           dashboard_url=''
@@ -92,7 +100,7 @@ jobs:
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
       - name: Comment quality gate in PR
-        if: github.event_name == 'pull_request' && always()
+        if: ${{ always() && github.event_name == 'pull_request' && env.SONAR_TOKEN != '' }}
         run: pnpm exec tsx scripts/post-sonar-quality-comment.ts
         env:
           APP_NAME: nebula-chat-db

--- a/.github/workflows/nebula-chat-langchain.yml
+++ b/.github/workflows/nebula-chat-langchain.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'libs/langchain/**'
+      - 'scripts/post-sonar-quality-comment.ts'
       - '.github/workflows/nebula-chat-langchain.yml'
   pull_request:
     branches: [main]
     paths:
       - 'libs/langchain/**'
+      - 'scripts/post-sonar-quality-comment.ts'
       - '.github/workflows/nebula-chat-langchain.yml'
   workflow_dispatch:
 
@@ -48,11 +50,16 @@ jobs:
             turbo-langchain-
       - name: Install dependencies
         run: pnpm install --ignore-scripts
-      - name: Build
-        run: pnpm turbo run build --filter=@nebula-chat/langchain
+      - name: Lint
+        run: pnpm exec eslint --report-unused-disable-directives --max-warnings=0 libs/langchain/
+      - name: Format check
+        run: pnpm exec prettier --check libs/langchain/
       - name: TypeScript check
         run: pnpm turbo run typecheck --filter=@nebula-chat/langchain
+      - name: Build
+        run: pnpm turbo run build --filter=@nebula-chat/langchain
       - name: SonarQube scan
+        if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         with:
           projectBaseDir: libs/langchain
@@ -68,12 +75,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Evaluate quality gate
         id: quality_gate
+        if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-quality-gate-action@v1.2.0
         with:
           scanMetadataReportFile: libs/langchain/.scannerwork/report-task.txt
           pollingTimeoutSec: 300
       - name: Publish Sonar summary
-        if: always()
+        if: ${{ always() && env.SONAR_TOKEN != '' }}
         run: |
           report_file='libs/langchain/.scannerwork/report-task.txt'
           dashboard_url=''
@@ -92,7 +100,7 @@ jobs:
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
       - name: Comment quality gate in PR
-        if: github.event_name == 'pull_request' && always()
+        if: ${{ always() && github.event_name == 'pull_request' && env.SONAR_TOKEN != '' }}
         run: pnpm exec tsx scripts/post-sonar-quality-comment.ts
         env:
           APP_NAME: nebula-chat-langchain

--- a/.github/workflows/nebula-chat-server.yml
+++ b/.github/workflows/nebula-chat-server.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Build
         run: pnpm turbo run build --filter=nebula-chat-server
       - name: SonarQube scan
+        if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         with:
           projectBaseDir: apps/nebula-chat-server
@@ -77,12 +78,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Evaluate quality gate
         id: quality_gate
+        if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-quality-gate-action@v1.2.0
         with:
           scanMetadataReportFile: apps/nebula-chat-server/.scannerwork/report-task.txt
           pollingTimeoutSec: 300
       - name: Publish Sonar summary
-        if: always()
+        if: ${{ always() && env.SONAR_TOKEN != '' }}
         run: |
           report_file='apps/nebula-chat-server/.scannerwork/report-task.txt'
           dashboard_url=''
@@ -101,7 +103,7 @@ jobs:
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
       - name: Comment quality gate in PR
-        if: github.event_name == 'pull_request' && always()
+        if: ${{ always() && github.event_name == 'pull_request' && env.SONAR_TOKEN != '' }}
         run: pnpm exec tsx scripts/post-sonar-quality-comment.ts
         env:
           APP_NAME: nebula-chat-server

--- a/knip.json
+++ b/knip.json
@@ -6,6 +6,14 @@
     },
     "apps/nebula-chat-server": {
       "project": ["src/**/*.ts"]
+    },
+    "libs/db": {
+      "entry": ["src/index.ts", "drizzle.config.ts"],
+      "project": ["src/**/*.ts"]
+    },
+    "libs/langchain": {
+      "entry": ["src/index.ts"],
+      "project": ["src/**/*.ts"]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
       "release-type": "node",
       "component": "nebula-chat",
       "include-component-in-tag": true,
-      "exclude-paths": ["apps/**"]
+      "exclude-paths": ["apps/**", "libs/**", "openapi/**"]
     },
     "apps/nebula-chat-client": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

Deep-dive fix of the CI/CD + SonarQube setup after the `libs/` additions. The pipelines were going red and the checks were inconsistent across packages.

**Root cause of the red checks:** every per-package build workflow ran the SonarQube scan, quality-gate and PR-comment steps unconditionally. GitHub does **not** expose `SONAR_TOKEN` to dependabot or fork PRs, so those steps failed on every such PR — turning all build checks red even when the code was fine.

### Changes

- **Sonar resilience (all 4 workflows):** guard every Sonar step (`scan`, `quality gate`, `summary`, `PR comment`) with `env.SONAR_TOKEN != ''`. When the token is unavailable (dependabot/forks) Sonar is *skipped*, not *failed*; lint/typecheck/build still gate the PR. On real PRs everything runs exactly as before.
- **Lib pipeline parity (`db`, `langchain`):** added the missing **Lint** and **Format check** steps, reordered to typecheck → build (matching the app workflows), and added the shared Sonar comment script to the path triggers.
- **release-please:** root `nebula-chat` component now excludes `libs/**` and `openapi/**` (previously only `apps/**`), fixing double version bumps when a lib or the OpenAPI spec changed.
- **knip:** added `libs/db` and `libs/langchain` to the workspace config so dead-code/unused-dep analysis covers the whole monorepo.
- **`.gitattributes`:** enforce LF so Prettier's `eol:lf` check behaves identically on Windows and CI.

Sonar projects now exist and run consistently for all four packages: `itsDaiton_nebula-chat-client`, `-server`, `-db`, `-langchain`.

### Test plan

- [x] `pnpm turbo run build --filter=nebula-chat-server` (builds libs first) — passes
- [x] `pnpm exec eslint ... libs/db/` and `libs/langchain/` — pass clean
- [x] Prettier check on LF-normalized libs — `All matched files use Prettier code style!`
- [x] `pnpm knip` with libs added — runs (report-only, exit 0)
- [x] All 4 workflow YAMLs parse; knip.json + release-please-config.json valid JSON
- [ ] Confirm a dependabot/fork PR now shows green build checks with Sonar steps skipped
- [ ] Confirm a normal PR still runs Sonar + posts the quality-gate comment

### Notes / follow-ups

- `libs/langchain` declares `langchain` and `langsmith` as direct deps but never imports them — candidate for removal (left out of this CI-focused PR).
- `.sonarlint/connectedMode.json` points the IDE to a monorepo-wide `itsDaiton_nebula-chat` project that has no CI analysis; left as-is since it's IDE-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)